### PR TITLE
Fix python35 tests

### DIFF
--- a/blocklib/blocks_generator.py
+++ b/blocklib/blocks_generator.py
@@ -44,16 +44,16 @@ def generate_blocks_2party(candidate_block_objs: Sequence[CandidateBlockingResul
 
 def generate_reverse_blocks(reversed_indices: Sequence[Dict]):
     """
-    Return a dictionary of record to block key mapping
+    Return a list of dictionaries of record to block key mapping
     :param reversed_indices: A list of dictionaries where key is the block key and value is a list of record IDs.
-    :return: rec_to_blockkey: A list of dictionaries where key is the record ID and value is a list of block key the record belongs to
+    :return: rec_to_blockkey: A list of dictionaries where key is the record ID and value is a set of block key the record belongs to
     """
     rec_to_blockkey = []
     for reversed_index in reversed_indices:
-        map_rec_block = defaultdict(list)
+        map_rec_block = defaultdict(set)
         for blk_key, rec_list in reversed_index.items():
             for rec in rec_list:
-                map_rec_block[rec].append(blk_key)
+                map_rec_block[rec].add(blk_key)
         rec_to_blockkey.append(map_rec_block)
     return rec_to_blockkey
 

--- a/blocklib/validation.py
+++ b/blocklib/validation.py
@@ -8,7 +8,7 @@ def load_schema(file_name: str):
     path = pathlib.Path(__file__).parent / '../docs/schemas' / file_name
 
     # schema_bytes = pkgutil.get_data('anonlinkclient', 'docs/schemas/{}'.format(file_name))
-    with open(path.resolve(), 'rt') as schema_file:
+    with open(str(path.resolve()), 'rt') as schema_file:
         try:
             return json.load(schema_file)
         except json.decoder.JSONDecodeError as e:

--- a/tests/test_blocks_generators.py
+++ b/tests/test_blocks_generators.py
@@ -14,8 +14,8 @@ class TestBlocksGenerator(unittest.TestCase):
              'Xu': [2, 3, 4]}
         ]
         record_to_blocks = generate_reverse_blocks(reversed_indices)
-        assert record_to_blocks[0] == {'r1': ['Fr'], 'r2': ['Fr'], 'r3': ['Jo'], 'r4': ['Jo']}
-        assert record_to_blocks[1] == {1: ['Li'], 2: ['Li', 'Xu'], 3: ['Li', 'Xu'], 4: ['Xu']}
+        assert record_to_blocks[0] == {'r1': {'Fr'}, 'r2': {'Fr'}, 'r3': {'Jo'}, 'r4': {'Jo'}}
+        assert record_to_blocks[1] == {1: {'Li'}, 2: {'Li', 'Xu'}, 3: {'Li', 'Xu'}, 4: {'Xu'}}
 
     def test_lambdafold(self):
         """Test block generator for PPRLLambdaFold method."""

--- a/tests/test_pprlindex.py
+++ b/tests/test_pprlindex.py
@@ -24,7 +24,12 @@ def test_summarize_reversed_index():
 
     stats = pprl.summarize_reversed_index(reversed_index)
     assert stats['num_of_blocks'] == 3
-    assert stats['len_of_blocks'] == [3, 2, 1]
+    # We are re-ordering the blocks length here as the method returns [2, 1, 3] with Python 3.5 instead of [3, 2, 1]
+    # in all other Python versions. This may be due to the fact that from Python3.6, the dictionaries have been updated
+    # to be ordered. https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6
+    length_of_blocks = stats['len_of_blocks']
+    length_of_blocks.sort()
+    assert length_of_blocks == [1, 2, 3]
     assert stats['min_size'] == 1
     assert stats['max_size'] == 3
     assert stats['avg_size'] == 2


### PR DESCRIPTION
Python 3.5 has some surprising behaviors compared to other python.
Two of them created issue in this repo:
 - `open` a file does not accept a PosixPath in python 3.5, only a string
 - a dictionary in python 3.5 is not ordered, because of which some methods were returning list (which are ordered) created passing though all the items from the dictionary. https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6

This PR can only be merged after the PR #18 as without it, the tests will not even run...

For completion and checking that it works, I created the branch `testouille` with these changes and the f-strings removal on top of the azure pipeline to get the feedback for python 3.5 (which I do not have locally). https://dev.azure.com/data61/Anonlink/_build/results?buildId=903 
Observe the step about building and testing python 3.5. Only two tests are failiing, the one described in the issue #15 
When merged, the branch `testouillle` should be deleted.