### PR TITLE
Feature17 fix typing error

### DIFF
--- a/blocklib/blocks_generator.py
+++ b/blocklib/blocks_generator.py
@@ -1,8 +1,10 @@
 """Module that implement final block generations."""
-from typing import Sequence, List, Dict, Any, Set
-import numpy as np
 from collections import defaultdict
-from .pprlindex import PPRLIndex
+from typing import Any, Dict, Sequence, Set
+
+import numpy as np
+
+from blocklib import PPRLIndex
 from .pprlpsig import PPRLIndexPSignature
 from .pprllambdafold import PPRLIndexLambdaFold
 from .candidate_blocks_generator import CandidateBlockingResult
@@ -50,7 +52,7 @@ def generate_reverse_blocks(reversed_indices: Sequence[Dict]):
     """
     rec_to_blockkey = []
     for reversed_index in reversed_indices:
-        map_rec_block: Dict[Any, List[Any]] = defaultdict(list)
+        map_rec_block: Dict[Any, Set[Any]] = defaultdict(set)
         for blk_key, rec_list in reversed_index.items():
             for rec in rec_list:
                 map_rec_block[rec].add(blk_key)
@@ -72,7 +74,7 @@ def generate_blocks_psig(reversed_indices: Sequence[Dict], block_states: Sequenc
         cbf: Set[int] = set()
         for bf_set in reversed_index:
             cbf = cbf.union(bf_set)
-
+        assert isinstance(block_states[0], PPRLIndexPSignature)
         bf_len = int(block_states[0].blocking_config.get("bf_len", None))
         bf_vector = np.zeros(bf_len, dtype=bool)
         bf_vector[list(cbf)] = True
@@ -91,5 +93,3 @@ def generate_blocks_psig(reversed_indices: Sequence[Dict], block_states: Sequenc
                 del reversed_index[bf_set]
 
     return reversed_indices
-
-

--- a/blocklib/blocks_generator.py
+++ b/blocklib/blocks_generator.py
@@ -1,5 +1,5 @@
 """Module that implement final block generations."""
-from typing import Sequence, List, Dict, Tuple
+from typing import Sequence, List, Dict, Any, Set
 import numpy as np
 from collections import defaultdict
 from .pprlindex import PPRLIndex
@@ -50,7 +50,7 @@ def generate_reverse_blocks(reversed_indices: Sequence[Dict]):
     """
     rec_to_blockkey = []
     for reversed_index in reversed_indices:
-        map_rec_block = defaultdict(list)
+        map_rec_block: Dict[Any, List[Any]] = defaultdict(list)
         for blk_key, rec_list in reversed_index.items():
             for rec in rec_list:
                 map_rec_block[rec].append(blk_key)
@@ -69,7 +69,7 @@ def generate_blocks_psig(reversed_indices: Sequence[Dict], block_states: Sequenc
     # generate candidate bloom filters
     candidate_bloom_filters = []
     for reversed_index, state in zip(reversed_indices, block_states):
-        cbf = set()
+        cbf: Set[int] = set()
         for bf_set in reversed_index:
             cbf = cbf.union(bf_set)
 
@@ -79,8 +79,8 @@ def generate_blocks_psig(reversed_indices: Sequence[Dict], block_states: Sequenc
         candidate_bloom_filters.append(bf_vector)
 
     # compute blocking filter (and operation)
-    cbf = np.sum(candidate_bloom_filters, axis=0)
-    block_filter = cbf >= threshold
+    cbf_array = np.sum(candidate_bloom_filters, axis=0)
+    block_filter = cbf_array >= threshold
 
     # filter reversed_indices with block filter
     for reversed_index in reversed_indices:

--- a/blocklib/candidate_blocks_generator.py
+++ b/blocklib/candidate_blocks_generator.py
@@ -1,16 +1,14 @@
 """Class that implement candidate block generations."""
-from typing import Sequence, List, Dict, Tuple
-import numpy as np
-from collections import defaultdict
+from typing import Dict, Sequence, Tuple, Type
 from .pprlindex import PPRLIndex
 from .pprlpsig import PPRLIndexPSignature
 from .pprllambdafold import PPRLIndexLambdaFold
 from .pprlkasn import PPRLIndexKAnonymousSortedNeighbour
 from .validation import validate_signature_config
 
-PPRLSTATES = {"p-sig": PPRLIndexPSignature,
-              "lambda-fold": PPRLIndexLambdaFold,
-              "kasn": PPRLIndexKAnonymousSortedNeighbour}
+PPRLSTATES: Dict[str, Type[PPRLIndex]] = {"p-sig": PPRLIndexPSignature,
+                                          "lambda-fold": PPRLIndexLambdaFold,
+                                          "kasn": PPRLIndexKAnonymousSortedNeighbour}
 
 
 class CandidateBlockingResult:

--- a/blocklib/encoding.py
+++ b/blocklib/encoding.py
@@ -1,7 +1,7 @@
 """Class to implement privacy preserving encoding."""
 import hashlib
 import numpy as np
-from typing import List
+from typing import List, Set
 
 
 def flip_bloom_filter(string: str, bf_len: int, num_hash_funct: int):
@@ -43,7 +43,7 @@ def generate_bloom_filter(list_of_strs: List[str], bf_len: int, num_hash_funct: 
     """
     # go through each signature and generate bloom filter of it
     # -- we only store the set of index that flipped to 1
-    candidate_bloom_filter = set()
+    candidate_bloom_filter: Set[int] = set()
 
     for signature in list_of_strs:
         bfset = flip_bloom_filter(signature, bf_len, num_hash_funct)

--- a/blocklib/pprlindex.py
+++ b/blocklib/pprlindex.py
@@ -1,19 +1,19 @@
 import random
 import statistics
-from typing import Sequence, Any, Dict, List, Set
+from typing import Any, Dict, List, Sequence, Set
+
 from blocklib.configuration import get_config
 
 
 class PPRLIndex:
     """Base class for PPRL indexing/blocking."""
 
-    def __init__(self):
+    def __init__(self, config: Dict = {}) -> None:
         """Initialise base class."""
         self.rec_dict = None
         self.ent_id_col = None
         self.rec_id_col = None
-        self.revert_index = {}
-        self.stats = {}
+        self.stats: Dict[str, Any] = {}
 
     def build_reversed_index(self, data: Sequence[Sequence]):
         """Method which builds the index for all database.

--- a/blocklib/pprlindex.py
+++ b/blocklib/pprlindex.py
@@ -1,6 +1,6 @@
 import random
 import statistics
-from typing import Sequence, Tuple, Dict
+from typing import Sequence, Any, Dict, List, Set
 from blocklib.configuration import get_config
 
 
@@ -39,7 +39,7 @@ class PPRLIndex:
         self.stats['med_size'] = int(statistics.median(lengths))
         self.stats['std_size'] = statistics.stdev(lengths)
         # find how many blocks each entity / record is a member of
-        rec_to_block = {}
+        rec_to_block: Dict[Any, List[Any]] = {}
         for block_id, block in reversed_index.items():
             for rec in block:
                 if rec in rec_to_block:
@@ -70,7 +70,7 @@ class PPRLIndex:
 
         # generate reference values
         random.seed(ref_random_seed)
-        ref_val_list = set()
+        ref_val_list: Set[str] = set()
 
         while len(ref_val_list) < num_vals:
             # random select one reference value allow repeat

--- a/blocklib/pprllambdafold.py
+++ b/blocklib/pprllambdafold.py
@@ -1,6 +1,6 @@
 import numpy as np
 from collections import defaultdict
-from typing import Dict, Sequence, Tuple
+from typing import Dict, Sequence, Any, List
 from blocklib.configuration import get_config
 from .pprlindex import PPRLIndex
 from .encoding import generate_bloom_filter
@@ -60,9 +60,9 @@ class PPRLIndexLambdaFold(PPRLIndex):
             record_ids = [x[self.record_id_col] for x in data]
         rnd = np.random.RandomState(self.random_state)
         # build Lambda fold tables and add to the invert index
-        invert_index = {}
+        invert_index: Dict[Any, List[Any]] = {}
         for i in range(self.mylambda):
-            lambda_table = defaultdict(list)
+            lambda_table: Dict[Any, Any] = defaultdict(list)
             # sample K indices from [0, bf-len]
             indices = rnd.choice(range(self.bf_len), self.K, replace=False)
             for rec_id, rec in zip(record_ids, data):

--- a/blocklib/pprlpsig.py
+++ b/blocklib/pprlpsig.py
@@ -1,6 +1,6 @@
 import time
 import numpy as np
-from typing import Dict, Sequence, Tuple
+from typing import Dict, Sequence, Any, List
 from blocklib.configuration import get_config
 from .pprlindex import PPRLIndex
 from .signature_generator import generate_signatures
@@ -32,7 +32,7 @@ class PPRLIndexPSignature(PPRLIndex):
 
     def build_reversed_index(self, data: Sequence[Sequence]):
         """Build inverted index given P-Sig method."""
-        reversed_index = {}
+        reversed_index: Dict[Any, List[Any]] = {}
         # Build index of records
         if self.rec_id_col is None:
             record_ids = np.arange(len(data))

--- a/blocklib/pprlpsig.py
+++ b/blocklib/pprlpsig.py
@@ -1,10 +1,10 @@
-import time
 import numpy as np
-from typing import Dict, Sequence, Any, List
-from blocklib.configuration import get_config
+from typing import Any, Dict, List, Sequence
+
+from .configuration import get_config
+from .encoding import flip_bloom_filter
 from .pprlindex import PPRLIndex
 from .signature_generator import generate_signatures
-from .encoding import generate_bloom_filter, flip_bloom_filter
 
 
 class PPRLIndexPSignature(PPRLIndex):
@@ -16,7 +16,7 @@ class PPRLIndexPSignature(PPRLIndex):
         This class includes an implementation of p-sig algorithm.
     """
 
-    def __init__(self, config: Dict):
+    def __init__(self, config: Dict) -> None:
         """Initialize the class and set the required parameters.
 
         Arguments:

--- a/blocklib/signature_generator.py
+++ b/blocklib/signature_generator.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Sequence, Tuple, Any
+from typing import Any, Callable, Dict, List, Sequence
 
 import fuzzy
 
@@ -95,7 +95,7 @@ def generate_by_metaphone(attr_ind: int, dtuple: Sequence):
 #################################################
 ########## Add strategy here ####################
 #################################################
-SIGNATURE_STRATEGIES = {
+SIGNATURE_STRATEGIES: Dict[str, Callable] = {
     'feature-value': generate_by_feature_value,
     "characters_at": generate_by_char_at,
     # 'n-gram': generate_by_n_gram,

--- a/blocklib/signature_generator.py
+++ b/blocklib/signature_generator.py
@@ -95,7 +95,7 @@ def generate_by_metaphone(attr_ind: int, dtuple: Sequence):
 #################################################
 ########## Add strategy here ####################
 #################################################
-SIGNATURE_STRATEGIES: Dict[str, Callable] = {
+SIGNATURE_STRATEGIES: Dict[str, Callable[..., str]] = {
     'feature-value': generate_by_feature_value,
     "characters_at": generate_by_char_at,
     # 'n-gram': generate_by_n_gram,

--- a/blocklib/signature_generator.py
+++ b/blocklib/signature_generator.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Sequence, Tuple
+from typing import List, Dict, Sequence, Tuple, Any
 
 import fuzzy
 
@@ -8,7 +8,7 @@ def generate_by_feature_value(attr_ind: int, dtuple: Sequence):
     return dtuple[attr_ind]
 
 
-def generate_by_char_at(attr_ind: int, dtuple: Sequence, pos: List[str]):
+def generate_by_char_at(attr_ind: int, dtuple: Sequence, pos: List[Any]):
     """ Generate signatures by select subset of characters in original features.
     >>> res = generate_by_char_at(2, ('harry potter', '4 Privet Drive', 'Little Whinging', 'Surrey'), [0, 3])
     >>> assert res == 'Lt'
@@ -51,7 +51,7 @@ def generate_by_char_at(attr_ind: int, dtuple: Sequence, pos: List[str]):
     return ''.join(sig)
 
 
-def generate_by_n_gram(attr_ind: int, dtuple: Sequence, n: int):
+def generate_by_n_gram(attr_ind: List[int], dtuple: Sequence, n: int):
     """Generate signatures by constructing n-grams.
     >>> res = generate_by_n_gram([0, 3], ('harry potter', '4 Privet Drive', 'Little Whinging', 'Surrey'), 2)
     >>> assert res == {'y ', 'ot', 'rS', 'Su', 'ry', 'er', 'ur', 'po', 're', 'ha', 'te', 'ar', 'tt', 'rr', ' p', 'ey'}

--- a/blocklib/simmeasure.py
+++ b/blocklib/simmeasure.py
@@ -2,7 +2,7 @@
 from blocklib.configuration import get_config
 import logging
 from abc import ABC
-from typing import Dict
+from typing import Dict, List, Tuple
 
 
 class SimMeasure(ABC):
@@ -100,10 +100,10 @@ class DiceSim(SimMeasure):
         self.ngram_padding = get_config(config, 'ngram_padding')
         self.padding_start_char = get_config(config, 'padding_start_char')
         self.padding_end_char = get_config(config, 'padding_end_char')
-        self.q_gram_cache = {}  # Store strings converted into q-grams. Keys in
+        self.q_gram_cache: Dict[str, List[str]] = {}  # Store strings converted into q-grams. Keys in
         # this will be strings and their values their
         # q-gram list
-        self.sim_cache = {}  # Store the string pair and its similarity in a
+        self.sim_cache: Dict[Tuple[str, str], float] = {}  # Store the string pair and its similarity in a
         # cache as well
 
     def sim(self, s1: str, s2: str, cache: bool = False):

--- a/tests/test_pprlindex.py
+++ b/tests/test_pprlindex.py
@@ -8,7 +8,6 @@ def test_init():
     assert pprl.rec_dict is None
     assert pprl.ent_id_col is None
     assert pprl.rec_id_col is None
-    assert pprl.revert_index == {}
     assert pprl.stats == {}
 
 


### PR DESCRIPTION
Update the type checking to pass mypy.
But few notes:
 - I removed the attribute `revert_index` from `PPRIndex` which was unused
 - the method `generate_blocks_psig` asks for a sequence of `PPRLIndex`, but under the hood requires a sequence of `PPRLIndexPSignature`. The main problem is that we are asking for the attribute `blocking_config` which is specific to `PPRLIndexPSignature`