### PR TITLE
Remove collision blocks in p-sig filtered reverse indices

### DIFF
--- a/blocklib/blocks_generator.py
+++ b/blocklib/blocks_generator.py
@@ -108,12 +108,12 @@ def generate_blocks_psig(reversed_indices: Sequence[Dict], block_states: Sequenc
                 del reversed_index[bf_set]
     # because of collisions in counting bloom filter, there are blocks only unique to one filtered index
     # only keep blocks that exist in at least threshold many reversed indices
-    keys = defaultdict(int)
+    keys = defaultdict(int)  # type: Dict[Set, int]
     for reversed_index in reversed_indices:
         for k in reversed_index:
             keys[k] += 1
     common_keys = [k for k in keys if keys[k] >= threshold]
-    for i in range(len(reversed_indices)):
-        reversed_index = reversed_indices[i]
-        reversed_indices[i] = dict((k, reversed_index[k]) for k in common_keys if k in reversed_index)
-    return reversed_indices
+    clean_reversed_indices = []  # type: List[Dict[Set, List]]
+    for reversed_index in reversed_indices:
+        clean_reversed_indices.append(dict((k, reversed_index[k]) for k in common_keys if k in reversed_index))
+    return clean_reversed_indices

--- a/blocklib/blocks_generator.py
+++ b/blocklib/blocks_generator.py
@@ -102,10 +102,18 @@ def generate_blocks_psig(reversed_indices: Sequence[Dict], block_states: Sequenc
 
     # filter reversed_indices with block filter
     for reversed_index in reversed_indices:
-
         has_matches = {bf_set: all(block_filter[i] for i in bf_set) for bf_set in reversed_index}
         for bf_set in has_matches:
             if not has_matches[bf_set]:
                 del reversed_index[bf_set]
-
+    # because of collisions in counting bloom filter, there are blocks only unique to one filtered index
+    # only keep blocks that exist in at least threshold many reversed indices
+    keys = defaultdict(int)
+    for reversed_index in reversed_indices:
+        for k in reversed_index:
+            keys[k] += 1
+    common_keys = [k for k in keys if keys[k] >= threshold]
+    for i in range(len(reversed_indices)):
+        reversed_index = reversed_indices[i]
+        reversed_indices[i] = dict((k, reversed_index[k]) for k in common_keys if k in reversed_index)
     return reversed_indices


### PR DESCRIPTION
The inconsistent block keys is due to collisions of bloom filter and thus collisions of counting bloom filter. In this pull request, I removed blocks that belongs to less than `threshold` many datasets. This can dramatically reduce the size of returned filtered reversed indices. The linking result will not be affected.

Close #56 