### PR TITLE
prevent block info from being lost in case of Bloom filter collision

### DIFF
--- a/blocklib/pprlpsig.py
+++ b/blocklib/pprlpsig.py
@@ -60,7 +60,10 @@ class PPRLIndexPSignature(PPRLIndex):
         reversed_index = {}
         for signature, rec_ids in filtered_reversed_index.items():
             bf_set = tuple(flip_bloom_filter(signature, bf_len, num_hash_func))
-            reversed_index[bf_set] = rec_ids
+            if bf_set in reversed_index:
+                reversed_index[bf_set].extend(rec_ids)
+            else:
+                reversed_index[bf_set] = rec_ids
 
         return reversed_index
 

--- a/tests/test_pprlpsig.py
+++ b/tests/test_pprlpsig.py
@@ -22,6 +22,36 @@ class TestPSig(unittest.TestCase):
             }
             PPRLIndexPSignature(config)
 
+    def test_combine_blocks_in_blocking_filter(self):
+        """During blocking filter generation, if there is an index collision, then we should combine the blocks
+        of the colliding signatures."""
+        data = [('id1', 'Joyce', 'Wang', 'Ashfield'),
+                ('id2', 'Brian', 'Hsu', 'Burwood')]
+        config = {
+            "blocking_features": [1],
+            "record-id-col": 0,
+            "filter": {
+                "type": "ratio",
+                "max": 1.0,
+                "min": 0.0,
+            },
+            "blocking-filter": {
+                "type": "bloom filter",
+                "number-hash-functions": 1,
+                "bf-len": 1,
+            },
+            "signatureSpecs": [
+                [
+                    {"type": "feature-value", "feature-idx": 1}
+                ]
+            ]
+
+        }
+        psig = PPRLIndexPSignature(config)
+        reversed_index = psig.build_reversed_index(data)
+        assert len(reversed_index) == 1
+        assert set(next(iter(reversed_index.values()))) == {'id1', 'id2'}
+
     def test_build_reversed_index(self):
         """Test build revert index."""
         data = [('id1', 'Joyce', 'Wang', 'Ashfield'),


### PR DESCRIPTION
I noticed that the blocking filter creation can loose some block info.

More specifically, if two signatures are mapped to the same Bloom filter index, then the record IDs of the second one overwrite the record IDs of the first one.
 
I propose to change it such that all record IDs are preserved in the case of a collision.
One caveat is that with this change the maximum block size can now be bigger than what is defined in the blocking config. 