### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## new version
 
+## 0.1.2
+Improvement on P-Sig blocking
+* Remove uncommon blocks due to collisions in bloom filter to reduce size of returned filtered reversed indices
+* Add feedback on coverage information of P-Sig blocking method i.e. if final blocks cover 100% records or not
+
 ## 0.1.1
 
 Correct markdown rendering in Pypi

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
 
 setuptools.setup(
     name="blocklib",
-    version="0.1.1",
+    version="0.1.2",
     author="Joyce Wang",
     author_email="joyce.wang@csiro.au",
     description="A library for blocking in record linkage",


### PR DESCRIPTION
release 0.1.2:

Improvement on P-Sig blocking
* Remove uncommon blocks due to collisions in bloom filter to reduce size of returned filtered reversed indices
* Add feedback on coverage information of P-Sig blocking method i.e. if final blocks cover 100% records or not
