### PR TITLE
Fix the case when we need to map column names to column index

### DIFF
--- a/blocklib/pprlindex.py
+++ b/blocklib/pprlindex.py
@@ -2,6 +2,7 @@ import random
 from typing import Any, Dict, List, Sequence, Optional
 from blocklib.configuration import get_config
 from blocklib.stats import reversed_index_stats
+from blocklib.utils import check_header
 
 
 class PPRLIndex:
@@ -13,6 +14,18 @@ class PPRLIndex:
         self.ent_id_col = None
         self.rec_id_col = None
         self.stats = {}  # type: Dict[str, Any]
+
+    def get_feature_to_index_map(self, header, data):
+        """Return feature name to feature index mapping if there is a header and feature is of type string."""
+        feature_type = type(self.blocking_features[0])
+        feature_to_index = None
+        tuple_type = type(data[0])  # if data is CLKs, then tuple_type will be str, otherwise a tuple
+
+        if header and feature_type == str and tuple_type != str:
+            check_header(header, data[0])
+            feature_to_index = {name: ind for ind, name in enumerate(header)}
+            self.blocking_features = [feature_to_index[x] for x in self.blocking_features]
+        return feature_to_index
 
     def build_reversed_index(self, data: Sequence[Sequence], verbose: bool, header: Optional[List[str]]  = None):
         """Method which builds the index for all database.

--- a/blocklib/pprlindex.py
+++ b/blocklib/pprlindex.py
@@ -14,6 +14,7 @@ class PPRLIndex:
         self.ent_id_col = None
         self.rec_id_col = None
         self.stats = {}  # type: Dict[str, Any]
+        self.blocking_features_index = None
 
     def get_feature_to_index_map(self, data: Sequence[Sequence], header: Optional[List[str]] = None):
         """Return feature name to feature index mapping if there is a header and feature is of type string."""
@@ -24,8 +25,20 @@ class PPRLIndex:
         if header and feature_type == str and tuple_type != str:
             check_header(header, data[0])
             feature_to_index = {name: ind for ind, name in enumerate(header)}
-            self.blocking_features = [feature_to_index[x] for x in self.blocking_features]  # type: ignore
+
         return feature_to_index
+
+    def set_blocking_features_index(self, feature_to_index):
+        """Set value of member variable blocking features index.
+
+        self.blocking_features could be string (column name) or int (column index)
+        self.blocking_features_index must be int (column index)
+
+        """
+        if feature_to_index:
+            self.blocking_features_index = [feature_to_index[x] for x in self.blocking_features]
+        else:
+            self.blocking_features_index = self.blocking_features
 
     def build_reversed_index(self, data: Sequence[Sequence], verbose: bool, header: Optional[List[str]]  = None):
         """Method which builds the index for all database.

--- a/blocklib/pprlindex.py
+++ b/blocklib/pprlindex.py
@@ -15,16 +15,16 @@ class PPRLIndex:
         self.rec_id_col = None
         self.stats = {}  # type: Dict[str, Any]
 
-    def get_feature_to_index_map(self, header, data):
+    def get_feature_to_index_map(self, data: Sequence[Sequence], header: Optional[List[str]] = None):
         """Return feature name to feature index mapping if there is a header and feature is of type string."""
-        feature_type = type(self.blocking_features[0])
+        feature_type = type(self.blocking_features[0])  # type: ignore
         feature_to_index = None
         tuple_type = type(data[0])  # if data is CLKs, then tuple_type will be str, otherwise a tuple
 
         if header and feature_type == str and tuple_type != str:
             check_header(header, data[0])
             feature_to_index = {name: ind for ind, name in enumerate(header)}
-            self.blocking_features = [feature_to_index[x] for x in self.blocking_features]
+            self.blocking_features = [feature_to_index[x] for x in self.blocking_features]  # type: ignore
         return feature_to_index
 
     def build_reversed_index(self, data: Sequence[Sequence], verbose: bool, header: Optional[List[str]]  = None):

--- a/blocklib/pprlindex.py
+++ b/blocklib/pprlindex.py
@@ -14,7 +14,6 @@ class PPRLIndex:
         self.ent_id_col = None
         self.rec_id_col = None
         self.stats = {}  # type: Dict[str, Any]
-        self.blocking_features_index = None
 
     def get_feature_to_index_map(self, data: Sequence[Sequence], header: Optional[List[str]] = None):
         """Return feature name to feature index mapping if there is a header and feature is of type string."""
@@ -28,7 +27,7 @@ class PPRLIndex:
 
         return feature_to_index
 
-    def set_blocking_features_index(self, feature_to_index):
+    def set_blocking_features_index(self, blocking_features, feature_to_index: Optional[Dict[str, int]] = None):
         """Set value of member variable blocking features index.
 
         self.blocking_features could be string (column name) or int (column index)
@@ -36,9 +35,9 @@ class PPRLIndex:
 
         """
         if feature_to_index:
-            self.blocking_features_index = [feature_to_index[x] for x in self.blocking_features]
+            self.blocking_features_index = [feature_to_index[x] for x in blocking_features]
         else:
-            self.blocking_features_index = self.blocking_features
+            self.blocking_features_index = blocking_features
 
     def build_reversed_index(self, data: Sequence[Sequence], verbose: bool, header: Optional[List[str]]  = None):
         """Method which builds the index for all database.

--- a/blocklib/pprllambdafold.py
+++ b/blocklib/pprllambdafold.py
@@ -25,6 +25,7 @@ class PPRLIndexLambdaFold(PPRLIndex):
 
         """
         super().__init__()
+        self.blocking_features = get_config(config, "blocking-features")
         # Lambda: number of redundant tables
         self.mylambda = int(get_config(config, "Lambda"))
         # bf-len: length of bloom filter
@@ -33,8 +34,6 @@ class PPRLIndexLambdaFold(PPRLIndex):
         self.num_hash_function = int(get_config(config, "num-hash-funcs"))
         # K: number of base Hamming LSH hashing functions
         self.K = int(get_config(config, "K"))
-        # blocking-features: list of blocking feature indices
-        self.blocking_features = get_config(config, "blocking-features")
         self.input_clks = get_config(config, 'input-clks')
         self.random_state = get_config(config, "random_state")
         self.record_id_col = config.get("record-id-col", None)
@@ -55,13 +54,7 @@ class PPRLIndexLambdaFold(PPRLIndex):
         :param verbose: ignored
         :return:
         """
-        # convert blocking feature to index if header is given
-        feature_type = type(self.blocking_features[0])
-        if header and feature_type == str and len(data[0]) > 1:
-            check_header(header, data[0])
-            feature_to_index = {name: ind for ind, name in enumerate(header)}
-            self.blocking_features = [feature_to_index[x] for x in self.blocking_features]
-
+        self.get_feature_to_index_map(header, data)
         # create record index lists
         if self.record_id_col is None:
             record_ids = list(range(len(data)))

--- a/blocklib/pprllambdafold.py
+++ b/blocklib/pprllambdafold.py
@@ -56,7 +56,8 @@ class PPRLIndexLambdaFold(PPRLIndex):
         :return:
         """
         # convert blocking feature to index if header is given
-        if header:
+        feature_type = type(self.blocking_features[0])
+        if header and feature_type == str and len(data[0]) > 1:
             check_header(header, data[0])
             feature_to_index = {name: ind for ind, name in enumerate(header)}
             self.blocking_features = [feature_to_index[x] for x in self.blocking_features]

--- a/blocklib/pprllambdafold.py
+++ b/blocklib/pprllambdafold.py
@@ -55,7 +55,7 @@ class PPRLIndexLambdaFold(PPRLIndex):
         :return:
         """
         feature_to_index = self.get_feature_to_index_map(data, header)
-        self.set_blocking_features_index(feature_to_index)
+        self.set_blocking_features_index(self.blocking_features, feature_to_index)
 
         # create record index lists
         if self.record_id_col is None:

--- a/blocklib/pprllambdafold.py
+++ b/blocklib/pprllambdafold.py
@@ -54,7 +54,7 @@ class PPRLIndexLambdaFold(PPRLIndex):
         :param verbose: ignored
         :return:
         """
-        self.get_feature_to_index_map(header, data)
+        self.get_feature_to_index_map(data, header)
         # create record index lists
         if self.record_id_col is None:
             record_ids = list(range(len(data)))

--- a/blocklib/pprlpsig.py
+++ b/blocklib/pprlpsig.py
@@ -30,6 +30,7 @@ class PPRLIndexPSignature(PPRLIndex):
 
         """
         super().__init__()
+        self.blocking_features = get_config(config, "blocking-features")
         self.filter_config = get_config(config, "filter")
         self.blocking_config = get_config(config, "blocking-filter")
         self.signature_strategies = get_config(config, 'signatureSpecs')
@@ -38,8 +39,9 @@ class PPRLIndexPSignature(PPRLIndex):
     def build_reversed_index(self, data: Sequence[Sequence], verbose: bool = False, header: Optional[List[str]] = None):
         """Build inverted index given P-Sig method."""
         # find blocking feature index if blocking feature type is string
+        feature_type = type(self.blocking_features[0])
         feature_to_index = None
-        if header:
+        if header and feature_type == str:
             check_header(header, data[0])
             feature_to_index = {name: ind for ind, name in enumerate(header)}
 

--- a/blocklib/pprlpsig.py
+++ b/blocklib/pprlpsig.py
@@ -37,7 +37,7 @@ class PPRLIndexPSignature(PPRLIndex):
 
     def build_reversed_index(self, data: Sequence[Sequence], verbose: bool = False, header: Optional[List[str]] = None):
         """Build inverted index given P-Sig method."""
-        feature_to_index = self.get_feature_to_index_map(header, data)
+        feature_to_index = self.get_feature_to_index_map(data, header)
         # Build index of records
         if self.rec_id_col is None:
             record_ids = np.arange(len(data))

--- a/blocklib/pprlpsig.py
+++ b/blocklib/pprlpsig.py
@@ -9,7 +9,6 @@ from .encoding import flip_bloom_filter
 from .pprlindex import PPRLIndex
 from .signature_generator import generate_signatures
 from .stats import reversed_index_per_strategy_stats
-from .utils import check_header
 
 
 class PPRLIndexPSignature(PPRLIndex):
@@ -38,13 +37,7 @@ class PPRLIndexPSignature(PPRLIndex):
 
     def build_reversed_index(self, data: Sequence[Sequence], verbose: bool = False, header: Optional[List[str]] = None):
         """Build inverted index given P-Sig method."""
-        # find blocking feature index if blocking feature type is string
-        feature_type = type(self.blocking_features[0])
-        feature_to_index = None
-        if header and feature_type == str:
-            check_header(header, data[0])
-            feature_to_index = {name: ind for ind, name in enumerate(header)}
-
+        feature_to_index = self.get_feature_to_index_map(header, data)
         # Build index of records
         if self.rec_id_col is None:
             record_ids = np.arange(len(data))

--- a/blocklib/pprlpsig.py
+++ b/blocklib/pprlpsig.py
@@ -38,6 +38,8 @@ class PPRLIndexPSignature(PPRLIndex):
     def build_reversed_index(self, data: Sequence[Sequence], verbose: bool = False, header: Optional[List[str]] = None):
         """Build inverted index given P-Sig method."""
         feature_to_index = self.get_feature_to_index_map(data, header)
+        self.set_blocking_features_index(feature_to_index)
+
         # Build index of records
         if self.rec_id_col is None:
             record_ids = np.arange(len(data))

--- a/blocklib/pprlpsig.py
+++ b/blocklib/pprlpsig.py
@@ -38,7 +38,7 @@ class PPRLIndexPSignature(PPRLIndex):
     def build_reversed_index(self, data: Sequence[Sequence], verbose: bool = False, header: Optional[List[str]] = None):
         """Build inverted index given P-Sig method."""
         feature_to_index = self.get_feature_to_index_map(data, header)
-        self.set_blocking_features_index(feature_to_index)
+        self.set_blocking_features_index(self.blocking_features, feature_to_index)
 
         # Build index of records
         if self.rec_id_col is None:

--- a/tests/test_pprllambdafold.py
+++ b/tests/test_pprllambdafold.py
@@ -95,7 +95,8 @@ class TestLambdaFold(unittest.TestCase):
         lambdafold = PPRLIndexLambdaFold(config)
         clk_filepath = Path(__file__).parent / 'data' / 'small_clk.json'
         with clk_filepath.open() as f:
-            data = json.load(f)['clks']
+            data = json.load(f)['clks']\
+
         reversed_index = lambdafold.build_reversed_index(data)
         assert len(reversed_index) == 5 * 4
         assert all([len(k) == 31 for k in reversed_index])

--- a/tests/test_pprllambdafold.py
+++ b/tests/test_pprllambdafold.py
@@ -31,7 +31,7 @@ class TestLambdaFold(unittest.TestCase):
         }
         lambdafold = PPRLIndexLambdaFold(config)
         record = [1, 'Xu', 'Li']
-        bloom_filter = lambdafold.__record_to_bf__(record)
+        bloom_filter = lambdafold.__record_to_bf__(record, config['blocking-features'])
         assert sum(bloom_filter) == 6
 
     def test_build_reversed_index(self):

--- a/tests/test_pprlpsig.py
+++ b/tests/test_pprlpsig.py
@@ -15,7 +15,7 @@ class TestPSig(unittest.TestCase):
         """Test p-sig configuration."""
         with self.assertRaises(ValueError):
             config = {
-                "blocking_features": [1],
+                "blocking-features": [1],
                 "filter": {
                     "type": "ratio",
                     "max": 0.02,
@@ -35,7 +35,7 @@ class TestPSig(unittest.TestCase):
         data = [('id1', 'Joyce', 'Wang', 'Ashfield'),
                 ('id2', 'Brian', 'Hsu', 'Burwood')]
         config = {
-            "blocking_features": [1],
+            "blocking-features": [1],
             "record-id-col": 0,
             "filter": {
                 "type": "ratio",
@@ -63,7 +63,7 @@ class TestPSig(unittest.TestCase):
         """Test build revert index."""
         global data
         config = {
-            "blocking_features": [1],
+            "blocking-features": [1],
             "record-id-col": 0,
             "filter": {
                 "type": "ratio",
@@ -93,7 +93,7 @@ class TestPSig(unittest.TestCase):
         global data
         header = ['ID', 'firstname', 'lastname', 'suburb']
         config = {
-            "blocking_features": ['firstname'],
+            "blocking-features": ['firstname'],
             "record-id-col": 0,
             "filter": {
                 "type": "ratio",
@@ -124,7 +124,7 @@ class TestPSig(unittest.TestCase):
         global data
         header = ['ID', 'firstname', 'lastname', 'suburb', 'postcode']  # extra feature - postcode
         config = {
-            "blocking_features": ['firstname'],
+            "blocking-features": ['firstname'],
             "record-id-col": 0,
             "filter": {
                 "type": "ratio",

--- a/tests/test_pprlpsig.py
+++ b/tests/test_pprlpsig.py
@@ -80,7 +80,6 @@ class TestPSig(unittest.TestCase):
                     {"type": "feature-value", "feature": 1}
                 ]
             ]
-
         }
         psig = PPRLIndexPSignature(config)
         reversed_index = psig.build_reversed_index(data, verbose=True)
@@ -119,6 +118,30 @@ class TestPSig(unittest.TestCase):
                                          config['blocking-filter']['number-hash-functions']))
         assert reversed_index == {str(bf_set): ['id4', 'id5']}
 
+        # test if results with column name and column index are the same
+        config_index = {
+            "blocking-features": [1],
+            "record-id-col": 0,
+            "filter": {
+                "type": "ratio",
+                "max": 0.5,
+                "min": 0.2,
+            },
+            "blocking-filter": {
+                "type": "bloom filter",
+                "number-hash-functions": 20,
+                "bf-len": 2048,
+            },
+            "signatureSpecs": [
+                [
+                    {"type": "feature-value", "feature": 1}
+                ]
+            ]
+        }
+        psig_col_index = PPRLIndexPSignature(config_index)
+        reversed_index_col_index = psig_col_index.build_reversed_index(data, verbose=True, header=header)
+        assert reversed_index == reversed_index_col_index
+
     def test_inconsistent_header(self):
         """Test when header dimension is not consistent with data dimension."""
         global data
@@ -141,9 +164,63 @@ class TestPSig(unittest.TestCase):
                     {"type": "feature-value", "feature": 'firstname'}
                 ]
             ]
-
         }
-
         psig = PPRLIndexPSignature(config)
         with self.assertRaises(AssertionError):
             psig.build_reversed_index(data, verbose=True, header=header)
+
+    def test_header_with_feature_type(self):
+        """Test different combination of header and feature column type."""
+        global data
+        header = ['ID', 'firstname', 'lastname', 'suburb']
+        config_name = {
+            "blocking-features": ['firstname'],
+            "record-id-col": 0,
+            "filter": {
+                "type": "ratio",
+                "max": 0.5,
+                "min": 0.2,
+            },
+            "blocking-filter": {
+                "type": "bloom filter",
+                "number-hash-functions": 20,
+                "bf-len": 2048,
+            },
+            "signatureSpecs": [
+                [
+                    {"type": "feature-value", "feature": 'firstname'}
+                ]
+            ]
+        }
+        config_index = {
+            "blocking-features": [1],
+            "record-id-col": 0,
+            "filter": {
+                "type": "ratio",
+                "max": 0.5,
+                "min": 0.2,
+            },
+            "blocking-filter": {
+                "type": "bloom filter",
+                "number-hash-functions": 20,
+                "bf-len": 2048,
+            },
+            "signatureSpecs": [
+                [
+                    {"type": "feature-value", "feature": 1}
+                ]
+            ]
+        }
+        psig_index = PPRLIndexPSignature(config_index)
+        psig_name = PPRLIndexPSignature(config_name)
+        # case1 header is given and feature type is column names
+        reversed_index1 = psig_name.build_reversed_index(data, verbose=True, header=header)
+        # case2 header is given and feature type is index
+        reversed_index2 = psig_index.build_reversed_index(data, verbose=True, header=header)
+        # case3 header is not given and feature type is index
+        reversed_index3 = psig_index.build_reversed_index(data, verbose=True, header=None)
+
+        # above 3 cases should give exactly same results
+        assert reversed_index1 == reversed_index2
+        assert reversed_index2 == reversed_index3
+


### PR DESCRIPTION
When testing latest blocklib, some tests failed. This PR fix it.