### PR TITLE
Removes a numpy int64 type

### DIFF
--- a/blocklib/pprlpsig.py
+++ b/blocklib/pprlpsig.py
@@ -2,8 +2,6 @@ import logging
 from collections import defaultdict
 from typing import Dict, List, Sequence, Any, Optional
 
-import numpy as np
-
 from .configuration import get_config
 from .encoding import flip_bloom_filter
 from .pprlindex import PPRLIndex, ReversedIndexResult

--- a/blocklib/pprlpsig.py
+++ b/blocklib/pprlpsig.py
@@ -42,7 +42,7 @@ class PPRLIndexPSignature(PPRLIndex):
 
         # Build index of records
         if self.rec_id_col is None:
-            record_ids = np.arange(len(data))
+            record_ids = list(range(len(data)))
         else:
             record_ids = [x[self.rec_id_col] for x in data]
 


### PR DESCRIPTION
Depending on the configuration the blocking result object returned by `generate_candidate_blocks` can have block values of a Python list of numpy.int64's, or of Python ints.

This PR switches to always Python int for record ids.