### PR TITLE
release 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## new version
 
+## 0.1.9
+
+* Bump supported Python versions #245
+
 ## 0.1.8
 
 * use logging instead of the `print` function  #138


### PR DESCRIPTION
to bring supported python versions for anonlink-client and blocklib in line. 